### PR TITLE
fix: substitute are_equal with `==` in xargs-test

### DIFF
--- a/tests/xargs-test.py
+++ b/tests/xargs-test.py
@@ -6,7 +6,7 @@ import sys
 from math import ceil
 from subprocess import PIPE, run
 
-from utils import VALGRIND_COMMAND, are_equal, color, format_result, run_command
+from utils import VALGRIND_COMMAND, color, format_result, run_command
 
 MAX_ARGS = 4
 
@@ -69,7 +69,7 @@ def run_test(binary_path, test_config, run_valgrind=False):
 
     result_lines, valgrind_report = test_packaging(binary_path, test_lines, run_valgrind)
 
-    res = are_equal(expected_lines, result_lines)
+    res = expected_lines == result_lines
 
     print(f'  {description}: {format_result(res)}')
 


### PR DESCRIPTION
Basado en [esto](https://github.com/fisop/fork/commit/2d85bcc3ab2b1266d925f70ab780eeb55a6cfd87), habria que hacer lo mismo en los tests de xarg. De lo contrario sucede esto:

```
Traceback (most recent call last):
  File "/fork/./tests/xargs-test.py", line 9, in <module>
    from utils import VALGRIND_COMMAND, are_equal, color, format_result, run_command
ImportError: cannot import name 'are_equal' from 'utils' (/fork/tests/utils.py)
```